### PR TITLE
docs: add dates for remaining Proxy-Wasm community meetings in CY 2025

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ Upcoming community meetings:
 | ---- | ---------- |------------ | ------------- |
 | 2025/05/29 | 17:00 | [link](https://meet.google.com/rjp-zixz-vzr) | [link](https://tel.meet/rjp-zixz-vzr?pin=6040905848018) |
 | 2025/06/26  | 17:00 | [link](https://meet.google.com/rjp-zixz-vzr) | [link](https://tel.meet/rjp-zixz-vzr?pin=6040905848018) |
+| 2025/07/31  | 17:00 | [link](https://meet.google.com/rjp-zixz-vzr) | [link](https://tel.meet/rjp-zixz-vzr?pin=6040905848018) |
+| 2025/08/28  | 17:00 | [link](https://meet.google.com/rjp-zixz-vzr) | [link](https://tel.meet/rjp-zixz-vzr?pin=6040905848018) |
+| 2025/09/25  | 17:00 | [link](https://meet.google.com/rjp-zixz-vzr) | [link](https://tel.meet/rjp-zixz-vzr?pin=6040905848018) |
+| 2025/10/30  | 17:00 | [link](https://meet.google.com/rjp-zixz-vzr) | [link](https://tel.meet/rjp-zixz-vzr?pin=6040905848018) |
+| 2025/11/27  | 17:00 | [link](https://meet.google.com/rjp-zixz-vzr) | [link](https://tel.meet/rjp-zixz-vzr?pin=6040905848018) |
+| 2025/12/18  | 17:00 | [link](https://meet.google.com/rjp-zixz-vzr) | [link](https://tel.meet/rjp-zixz-vzr?pin=6040905848018) |
 
 ## Issues
 


### PR DESCRIPTION
Meetings are on the last Thursday of each month, with the exception of November and December, where they have been shifted one week earlier to avoid holidays.